### PR TITLE
Enhance university hierarchy and location filtering

### DIFF
--- a/UI/src/components/pages/AdminUniversitiesPage.tsx
+++ b/UI/src/components/pages/AdminUniversitiesPage.tsx
@@ -314,25 +314,20 @@ export default function AdminUniversitiesPage() {
     });
   };
 
-  const toggleNode = (nodeId: string, path: number[] = []) => {
-    setTreeData(prev => {
-      const newData = [...prev];
-      let current = newData;
-      
-      for (let i = 0; i < path.length; i++) {
-        current = current[path[i]].children!;
-      }
-      
-      const nodeIndex = current.findIndex(node => node.id === nodeId);
-      if (nodeIndex !== -1) {
-        current[nodeIndex] = {
-          ...current[nodeIndex],
-          expanded: !current[nodeIndex].expanded
-        };
-      }
-      
-      return newData;
-    });
+  const toggleNode = (nodeId: string) => {
+    const updateNode = (nodes: TreeNode[]): TreeNode[] => {
+      return nodes.map(node => {
+        if (node.id === nodeId) {
+          return { ...node, expanded: !node.expanded };
+        }
+        if (node.children) {
+          return { ...node, children: updateNode(node.children) };
+        }
+        return node;
+      });
+    };
+
+    setTreeData(updateNode(treeData));
   };
 
   const handleCreate = async () => {
@@ -412,7 +407,7 @@ export default function AdminUniversitiesPage() {
     }
   };
 
-  const renderTreeNode = (node: TreeNode, path: number[] = [], depth: number = 0) => {
+  const renderTreeNode = (node: TreeNode, depth: number = 0): React.ReactNode => {
     const hasChildren = node.children && node.children.length > 0;
     const isExpanded = node.expanded;
 
@@ -426,7 +421,7 @@ export default function AdminUniversitiesPage() {
         >
           {hasChildren ? (
             <button
-              onClick={() => toggleNode(node.id, path)}
+              onClick={() => toggleNode(node.id)}
               className="p-1 hover:bg-gray-200 rounded"
             >
               {isExpanded ? (
@@ -515,8 +510,8 @@ export default function AdminUniversitiesPage() {
 
         {hasChildren && isExpanded && (
           <div>
-            {node.children!.map((child, index) =>
-              renderTreeNode(child, [...path, index], depth + 1)
+            {node.children!.map((child) =>
+              renderTreeNode(child, depth + 1)
             )}
           </div>
         )}
@@ -933,7 +928,7 @@ export default function AdminUniversitiesPage() {
               </h2>
               <div className="space-y-1">
                 {filterTreeData(treeData, searchTerm).length > 0 ? (
-                  filterTreeData(treeData, searchTerm).map((node, index) => renderTreeNode(node, [index]))
+                  filterTreeData(treeData, searchTerm).map((node) => renderTreeNode(node))
                 ) : (
                   <div className="flex items-center justify-center h-64 text-gray-500">
                     <div className="text-center">

--- a/main.py
+++ b/main.py
@@ -5288,7 +5288,7 @@ def build_references_tree(
             for ch in children:
                 # include only children whose level <= e_int
                 ch_level = int(ch.get("level") or 0)
-                if ch_level < e_int:
+                if ch_level <= e_int:  # Fixed: include stop level
                     ch["children"] = attach_limited(ch.get("id"))
                 else:
                     ch["children"] = []
@@ -5383,7 +5383,7 @@ def build_references_tree(
             for ch in children:
                 # limit by stop level index
                 lvl = map_to_idx.get(str(ch.get("level") or "").lower(), 99)
-                if lvl < e_idx:
+                if lvl <= e_idx:  # Fixed: include stop level
                     ch["children"] = attach_geo(ch.get("id"))
                 else:
                     ch["children"] = []


### PR DESCRIPTION
Fix university hierarchy tree expansion and ensure geographic entity filters display all selected levels.

The university tree expansion was broken due to a path-based `toggleNode` implementation in `AdminUniversitiesPage.tsx`, which has been refactored to a recursive ID-based approach. Additionally, the geographic entity and category tree builders in `main.py` incorrectly used `<` instead of `<=` when checking the `stop_level`, preventing the final selected level from being included in the hierarchy. This has been corrected to include the stop level.

---
<a href="https://cursor.com/background-agent?bcId=bc-7382d1b0-dc03-4f32-b056-d412c4373319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7382d1b0-dc03-4f32-b056-d412c4373319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

