### PR TITLE
Fix academic persons CRUD and API integration

### DIFF
--- a/UI/src/components/pages/AdminAcademicPersonsPage.tsx
+++ b/UI/src/components/pages/AdminAcademicPersonsPage.tsx
@@ -78,20 +78,20 @@ export default function AdminAcademicPersonsPage() {
   });
   const [modal, setModal] = useState<ModalState>({ isOpen: false, mode: 'create' });
   const [formData, setFormData] = useState<AcademicPersonCreate>({
-    complete_name_fr: undefined,
-    complete_name_ar: undefined,
-    first_name_fr: undefined,
-    last_name_fr: undefined,
-    first_name_ar: undefined,
-    last_name_ar: undefined,
-    title: undefined,
-    university_id: undefined,
-    faculty_id: undefined,
-    school_id: undefined,
-    external_institution_name: undefined,
-    external_institution_country: undefined,
-    external_institution_type: undefined,
-    user_id: undefined
+    complete_name_fr: '',
+    complete_name_ar: '',
+    first_name_fr: '',
+    last_name_fr: '',
+    first_name_ar: '',
+    last_name_ar: '',
+    title: '',
+    university_id: '',
+    faculty_id: '',
+    school_id: '',
+    external_institution_name: '',
+    external_institution_country: '',
+    external_institution_type: '',
+    user_id: ''
   });
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -376,7 +376,15 @@ export default function AdminAcademicPersonsPage() {
     if (!validateForm()) return;
     
     try {
-      await apiService.adminCreate('academic-persons', formData);
+      // Clean form data - convert empty strings to undefined for optional fields
+      const cleanedData = Object.fromEntries(
+        Object.entries(formData).map(([key, value]) => [
+          key, 
+          value === '' ? undefined : value
+        ])
+      );
+      
+      await apiService.adminCreate('academic-persons', cleanedData);
       setModal({ isOpen: false, mode: 'create' });
       resetForm();
       loadData();
@@ -395,7 +403,15 @@ export default function AdminAcademicPersonsPage() {
     if (!validateForm()) return;
     
     try {
-      await apiService.adminUpdate('academic-persons', modal.item.id, formData);
+      // Clean form data - convert empty strings to undefined for optional fields
+      const cleanedData = Object.fromEntries(
+        Object.entries(formData).map(([key, value]) => [
+          key, 
+          value === '' ? undefined : value
+        ])
+      );
+      
+      await apiService.adminUpdate('academic-persons', modal.item.id, cleanedData);
       setModal({ isOpen: false, mode: 'edit' });
       loadData();
     } catch (error) {
@@ -424,20 +440,20 @@ export default function AdminAcademicPersonsPage() {
 
   const resetForm = () => {
     setFormData({
-      complete_name_fr: undefined,
-      complete_name_ar: undefined,
-      first_name_fr: undefined,
-      last_name_fr: undefined,
-      first_name_ar: undefined,
-      last_name_ar: undefined,
-      title: undefined,
-      university_id: undefined,
-      faculty_id: undefined,
-      school_id: undefined,
-      external_institution_name: undefined,
-      external_institution_country: undefined,
-      external_institution_type: undefined,
-      user_id: undefined
+      complete_name_fr: '',
+      complete_name_ar: '',
+      first_name_fr: '',
+      last_name_fr: '',
+      first_name_ar: '',
+      last_name_ar: '',
+      title: '',
+      university_id: '',
+      faculty_id: '',
+      school_id: '',
+      external_institution_name: '',
+      external_institution_country: '',
+      external_institution_type: '',
+      user_id: ''
     });
   };
 
@@ -446,20 +462,20 @@ export default function AdminAcademicPersonsPage() {
     
     if (mode === 'edit' && item) {
       setFormData({
-        complete_name_fr: item.complete_name_fr || undefined,
-        complete_name_ar: item.complete_name_ar || undefined,
-        first_name_fr: item.first_name_fr || undefined,
-        last_name_fr: item.last_name_fr || undefined,
-        first_name_ar: item.first_name_ar || undefined,
-        last_name_ar: item.last_name_ar || undefined,
-        title: item.title || undefined,
-        university_id: item.university_id || undefined,
-        faculty_id: item.faculty_id || undefined,
-        school_id: item.school_id || undefined,
-        external_institution_name: item.external_institution_name || undefined,
-        external_institution_country: item.external_institution_country || undefined,
-        external_institution_type: item.external_institution_type || undefined,
-        user_id: item.user_id || undefined
+        complete_name_fr: item.complete_name_fr || '',
+        complete_name_ar: item.complete_name_ar || '',
+        first_name_fr: item.first_name_fr || '',
+        last_name_fr: item.last_name_fr || '',
+        first_name_ar: item.first_name_ar || '',
+        last_name_ar: item.last_name_ar || '',
+        title: item.title || '',
+        university_id: item.university_id || '',
+        faculty_id: item.faculty_id || '',
+        school_id: item.school_id || '',
+        external_institution_name: item.external_institution_name || '',
+        external_institution_country: item.external_institution_country || '',
+        external_institution_type: item.external_institution_type || '',
+        user_id: item.user_id || ''
       });
     } else if (mode === 'create') {
       resetForm();
@@ -570,7 +586,7 @@ export default function AdminAcademicPersonsPage() {
                     <input
                       type="text"
                       value={formData.first_name_fr || ''}
-                      onChange={(e) => setFormData({ ...formData, first_name_fr: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, first_name_fr: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     />
                   </div>
@@ -581,7 +597,7 @@ export default function AdminAcademicPersonsPage() {
                     <input
                       type="text"
                       value={formData.last_name_fr || ''}
-                      onChange={(e) => setFormData({ ...formData, last_name_fr: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, last_name_fr: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     />
                   </div>
@@ -593,7 +609,7 @@ export default function AdminAcademicPersonsPage() {
                   <input
                     type="text"
                     value={formData.complete_name_fr || ''}
-                    onChange={(e) => setFormData({ ...formData, complete_name_fr: e.target.value || undefined })}
+                    onChange={(e) => setFormData({ ...formData, complete_name_fr: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     placeholder="Si différent de Prénom + Nom"
                   />
@@ -611,7 +627,7 @@ export default function AdminAcademicPersonsPage() {
                     <input
                       type="text"
                       value={formData.first_name_ar || ''}
-                      onChange={(e) => setFormData({ ...formData, first_name_ar: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, first_name_ar: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       dir="rtl"
                     />
@@ -623,7 +639,7 @@ export default function AdminAcademicPersonsPage() {
                     <input
                       type="text"
                       value={formData.last_name_ar || ''}
-                      onChange={(e) => setFormData({ ...formData, last_name_ar: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, last_name_ar: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       dir="rtl"
                     />
@@ -636,7 +652,7 @@ export default function AdminAcademicPersonsPage() {
                   <input
                     type="text"
                     value={formData.complete_name_ar || ''}
-                    onChange={(e) => setFormData({ ...formData, complete_name_ar: e.target.value || undefined })}
+                    onChange={(e) => setFormData({ ...formData, complete_name_ar: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     dir="rtl"
                     placeholder="إذا كان مختلفاً عن الاسم + اللقب"
@@ -653,7 +669,7 @@ export default function AdminAcademicPersonsPage() {
                   </label>
                   <select
                     value={formData.title || ''}
-                    onChange={(e) => setFormData({ ...formData, title: e.target.value || undefined })}
+                    onChange={(e) => setFormData({ ...formData, title: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   >
                     <option value="">Sélectionner un titre</option>
@@ -677,7 +693,7 @@ export default function AdminAcademicPersonsPage() {
                     </label>
                     <select
                       value={formData.university_id || ''}
-                      onChange={(e) => setFormData({ ...formData, university_id: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, university_id: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     >
                       <option value="">Sélectionner une université</option>
@@ -694,7 +710,7 @@ export default function AdminAcademicPersonsPage() {
                     </label>
                     <select
                       value={formData.faculty_id || ''}
-                      onChange={(e) => setFormData({ ...formData, faculty_id: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, faculty_id: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     >
                       <option value="">Sélectionner une faculté</option>
@@ -711,7 +727,7 @@ export default function AdminAcademicPersonsPage() {
                     </label>
                     <select
                       value={formData.school_id || ''}
-                      onChange={(e) => setFormData({ ...formData, school_id: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, school_id: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     >
                       <option value="">Sélectionner une école</option>
@@ -736,7 +752,7 @@ export default function AdminAcademicPersonsPage() {
                     <input
                       type="text"
                       value={formData.external_institution_name || ''}
-                      onChange={(e) => setFormData({ ...formData, external_institution_name: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, external_institution_name: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       placeholder="Nom de l'institution externe"
                     />
@@ -748,7 +764,7 @@ export default function AdminAcademicPersonsPage() {
                     <input
                       type="text"
                       value={formData.external_institution_country || ''}
-                      onChange={(e) => setFormData({ ...formData, external_institution_country: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, external_institution_country: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       placeholder="Pays de l'institution"
                     />
@@ -759,7 +775,7 @@ export default function AdminAcademicPersonsPage() {
                     </label>
                     <select
                       value={formData.external_institution_type || ''}
-                      onChange={(e) => setFormData({ ...formData, external_institution_type: e.target.value || undefined })}
+                      onChange={(e) => setFormData({ ...formData, external_institution_type: e.target.value })}
                       className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     >
                       <option value="">Sélectionner le type</option>
@@ -783,7 +799,7 @@ export default function AdminAcademicPersonsPage() {
                   <input
                     type="text"
                     value={formData.user_id || ''}
-                    onChange={(e) => setFormData({ ...formData, user_id: e.target.value || undefined })}
+                    onChange={(e) => setFormData({ ...formData, user_id: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     placeholder="UUID de l'utilisateur associé"
                   />

--- a/UI/src/services/api.ts
+++ b/UI/src/services/api.ts
@@ -60,7 +60,7 @@ class ApiService {
     departments: '/admin/departments',
     categories: '/admin/categories',
     keywords: '/admin/keywords',
-    academic_persons: '/admin/academic-persons',
+    'academic-persons': '/admin/academic-persons',
     degrees: '/admin/degrees',
     languages: '/admin/languages',
     geographic_entities: '/admin/geographic-entities',

--- a/test_academic_persons.html
+++ b/test_academic_persons.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Academic Persons API Test</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .test-section { margin: 20px 0; padding: 15px; border: 1px solid #ccc; border-radius: 5px; }
+        .success { background-color: #d4edda; border-color: #c3e6cb; }
+        .error { background-color: #f8d7da; border-color: #f5c6cb; }
+        pre { background-color: #f8f9fa; padding: 10px; border-radius: 3px; overflow-x: auto; }
+        button { padding: 10px 15px; margin: 5px; background-color: #007bff; color: white; border: none; border-radius: 3px; cursor: pointer; }
+        button:hover { background-color: #0056b3; }
+    </style>
+</head>
+<body>
+    <h1>Academic Persons API Test</h1>
+    <p>Testing the fixed API endpoints for academic persons CRUD operations.</p>
+
+    <div class="test-section">
+        <h2>Test 1: GET /admin/academic-persons</h2>
+        <button onclick="testGetAcademicPersons()">Test GET Request</button>
+        <div id="get-result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Test 2: POST /admin/academic-persons</h2>
+        <button onclick="testCreateAcademicPerson()">Test POST Request</button>
+        <div id="post-result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Test 3: PUT /admin/academic-persons/{id}</h2>
+        <button onclick="testUpdateAcademicPerson()">Test PUT Request</button>
+        <div id="put-result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Test 4: DELETE /admin/academic-persons/{id}</h2>
+        <button onclick="testDeleteAcademicPerson()">Test DELETE Request</button>
+        <div id="delete-result"></div>
+    </div>
+
+    <script>
+        const API_BASE = 'http://localhost:8000';
+        let testPersonId = null;
+
+        async function makeRequest(url, options = {}) {
+            try {
+                const response = await fetch(url, {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        ...options.headers
+                    },
+                    ...options
+                });
+                
+                const data = await response.json();
+                return { success: response.ok, status: response.status, data };
+            } catch (error) {
+                return { success: false, error: error.message };
+            }
+        }
+
+        async function testGetAcademicPersons() {
+            const result = await makeRequest(`${API_BASE}/admin/academic-persons?limit=5&page=1`);
+            const resultDiv = document.getElementById('get-result');
+            
+            if (result.success) {
+                resultDiv.innerHTML = `
+                    <div class="success">
+                        <h3>✅ GET Request Successful</h3>
+                        <p><strong>Status:</strong> ${result.status}</p>
+                        <p><strong>Data Count:</strong> ${result.data.data ? result.data.data.length : 0}</p>
+                        <pre>${JSON.stringify(result.data, null, 2)}</pre>
+                    </div>
+                `;
+                // Store the first person's ID for other tests
+                if (result.data.data && result.data.data.length > 0) {
+                    testPersonId = result.data.data[0].id;
+                }
+            } else {
+                resultDiv.innerHTML = `
+                    <div class="error">
+                        <h3>❌ GET Request Failed</h3>
+                        <p><strong>Error:</strong> ${result.error || 'Unknown error'}</p>
+                        <pre>${JSON.stringify(result, null, 2)}</pre>
+                    </div>
+                `;
+            }
+        }
+
+        async function testCreateAcademicPerson() {
+            const newPerson = {
+                complete_name_fr: "Test Person",
+                first_name_fr: "Test",
+                last_name_fr: "Person",
+                title: "Dr",
+                university_id: "550e8400-e29b-41d4-a716-446655440010"
+            };
+
+            const result = await makeRequest(`${API_BASE}/admin/academic-persons`, {
+                method: 'POST',
+                body: JSON.stringify(newPerson)
+            });
+            
+            const resultDiv = document.getElementById('post-result');
+            
+            if (result.success) {
+                resultDiv.innerHTML = `
+                    <div class="success">
+                        <h3>✅ POST Request Successful</h3>
+                        <p><strong>Status:</strong> ${result.status}</p>
+                        <p><strong>Created Person ID:</strong> ${result.data.id}</p>
+                        <pre>${JSON.stringify(result.data, null, 2)}</pre>
+                    </div>
+                `;
+                testPersonId = result.data.id;
+            } else {
+                resultDiv.innerHTML = `
+                    <div class="error">
+                        <h3>❌ POST Request Failed</h3>
+                        <p><strong>Error:</strong> ${result.error || 'Unknown error'}</p>
+                        <pre>${JSON.stringify(result, null, 2)}</pre>
+                    </div>
+                `;
+            }
+        }
+
+        async function testUpdateAcademicPerson() {
+            if (!testPersonId) {
+                document.getElementById('put-result').innerHTML = `
+                    <div class="error">
+                        <h3>❌ No Person ID Available</h3>
+                        <p>Please run the GET or POST test first to get a person ID.</p>
+                    </div>
+                `;
+                return;
+            }
+
+            const updateData = {
+                title: "Prof",
+                complete_name_fr: "Updated Test Person"
+            };
+
+            const result = await makeRequest(`${API_BASE}/admin/academic-persons/${testPersonId}`, {
+                method: 'PUT',
+                body: JSON.stringify(updateData)
+            });
+            
+            const resultDiv = document.getElementById('put-result');
+            
+            if (result.success) {
+                resultDiv.innerHTML = `
+                    <div class="success">
+                        <h3>✅ PUT Request Successful</h3>
+                        <p><strong>Status:</strong> ${result.status}</p>
+                        <p><strong>Updated Person ID:</strong> ${result.data.id}</p>
+                        <pre>${JSON.stringify(result.data, null, 2)}</pre>
+                    </div>
+                `;
+            } else {
+                resultDiv.innerHTML = `
+                    <div class="error">
+                        <h3>❌ PUT Request Failed</h3>
+                        <p><strong>Error:</strong> ${result.error || 'Unknown error'}</p>
+                        <pre>${JSON.stringify(result, null, 2)}</pre>
+                    </div>
+                `;
+            }
+        }
+
+        async function testDeleteAcademicPerson() {
+            if (!testPersonId) {
+                document.getElementById('delete-result').innerHTML = `
+                    <div class="error">
+                        <h3>❌ No Person ID Available</h3>
+                        <p>Please run the GET or POST test first to get a person ID.</p>
+                    </div>
+                `;
+                return;
+            }
+
+            const result = await makeRequest(`${API_BASE}/admin/academic-persons/${testPersonId}`, {
+                method: 'DELETE'
+            });
+            
+            const resultDiv = document.getElementById('delete-result');
+            
+            if (result.success) {
+                resultDiv.innerHTML = `
+                    <div class="success">
+                        <h3>✅ DELETE Request Successful</h3>
+                        <p><strong>Status:</strong> ${result.status}</p>
+                        <pre>${JSON.stringify(result.data, null, 2)}</pre>
+                    </div>
+                `;
+                testPersonId = null; // Reset for next test
+            } else {
+                resultDiv.innerHTML = `
+                    <div class="error">
+                        <h3>❌ DELETE Request Failed</h3>
+                        <p><strong>Error:</strong> ${result.error || 'Unknown error'}</p>
+                        <pre>${JSON.stringify(result, null, 2)}</pre>
+                    </div>
+                `;
+            }
+        }
+
+        // Auto-run the GET test on page load
+        window.onload = function() {
+            testGetAcademicPersons();
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fix CRUD operations for `/admin/academic-persons` by correcting the API endpoint key mismatch and refining form data handling.

The frontend was making requests to `/undefined` due to a key mismatch (`academic_persons` vs `academic-persons`) in the API service configuration. Additionally, form data handling was updated to consistently use empty strings for optional fields, which are then converted to `undefined` before being sent to the API, ensuring proper API schema compliance.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a84a306-91c4-4d9e-99a0-b4b9a9855158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a84a306-91c4-4d9e-99a0-b4b9a9855158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

