### PR TITLE
Fix duplicate departments state declaration

### DIFF
--- a/UI/src/components/pages/AdminThesisPage.tsx
+++ b/UI/src/components/pages/AdminThesisPage.tsx
@@ -87,7 +87,6 @@ export default function AdminThesisPage() {
   // Reference data
   const [universities, setUniversities] = useState<UniversityResponse[]>([]);
   const [faculties, setFaculties] = useState<FacultyResponse[]>([]);
-  const [departments, setDepartments] = useState<any[]>([]);
   const [departments, setDepartments] = useState<DepartmentResponse[]>([]);
   const [degrees, setDegrees] = useState<DegreeResponse[]>([]);
   const [languages, setLanguages] = useState<LanguageResponse[]>([]);


### PR DESCRIPTION
Remove duplicate `departments` state declaration to resolve a compilation error.

The component had two declarations for `departments`. The `any[]` typed declaration was removed, keeping the `DepartmentResponse[]` typed one for better type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-0eb8215d-8155-47e6-b510-0df254e4287f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0eb8215d-8155-47e6-b510-0df254e4287f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

