### PR TITLE
Feat/treeview foundation

### DIFF
--- a/FOUNDATION_PR_SPEC.md
+++ b/FOUNDATION_PR_SPEC.md
@@ -1,0 +1,53 @@
+## Foundation PR: TreeView Consolidation and Mappers
+
+Branch: `feat/treeview-foundation`
+
+Scope:
+- Freeze shared TreeView API and introduce reusable mapping utilities for hierarchical data.
+- Align one representative admin page to the shared TreeView usage pattern to set the standard for parallel refactors.
+
+Changes included:
+1) UI utility
+   - `UI/src/utils/treeMappers.ts`
+     - `mapApiTreeToUiNodes(data, typeResolver)` generic mapper from API nested tree (`TreeNodeData[]`) to UI `TreeNode[]`.
+     - Provided resolvers: `universitiesHierarchyResolver`, `schoolsHierarchyResolver`, `categoriesHierarchyResolver`, `geographicHierarchyResolver`.
+
+2) Academic Persons page alignment
+   - `UI/src/components/pages/AdminAcademicPersonsPage.tsx`
+     - Replace incorrect usage of TreeView props (now uses `nodes` instead of non-existent `data`).
+     - Provide minimal `type` mapping in converted nodes for consistent iconography.
+
+Non-goals (do NOT change in this PR):
+- No edits to `UI/src/components/ui/TreeView/TreeView.tsx` or `UI/src/types/tree.ts` (API is considered frozen for downstream parallel work).
+- No broad refactors of other admin pages yet.
+
+Acceptance criteria:
+- Academic Persons "tree" view renders without runtime errors and respects search/expand behavior.
+- Lint passes for changed files.
+- The mappers compile and export without unused errors; they are ready for import by other pages.
+
+Follow-up PR responsibilities (parallelizable):
+1) Agent A (Institutions stack)
+   - Refactor `AdminUniversitiesPage.tsx`, `AdminFacultiesPage.tsx`, `AdminDepartmentsPage.tsx`, `AdminSchoolsPage.tsx` to use shared `TreeView` for tree mode.
+   - Use `mapApiTreeToUiNodes` with `universitiesHierarchyResolver` (and `schoolsHierarchyResolver` where applicable).
+   - Keep list/table modes unchanged.
+
+2) Agent B (Taxonomies)
+   - Refactor `AdminCategoriesPage.tsx` to use shared `TreeView` (tree mode).
+   - Use `mapApiTreeToUiNodes` + `categoriesHierarchyResolver`.
+
+3) Agent C (Geography)
+   - Refactor `AdminGeographicEntitiesPage.tsx` to use shared `TreeView` (tree mode and selection modals if desired).
+   - Use `mapApiTreeToUiNodes` + `geographicHierarchyResolver`.
+
+Coordination and conflict-avoidance:
+- All agents must branch off `feat/treeview-foundation` AFTER it merges.
+- Do not modify `TreeView`, `types/tree.ts`, or `utils/treeMappers.ts` in follow-up PRs. If an enhancement is needed, coordinate a separate small PR first.
+- Limit diffs to the page(s) owned by the agent; avoid formatting unrelated code.
+- Rebase each PR on latest main before review.
+
+Testing and validation checklist per agent:
+- Tree mode loads from existing API calls; node labels and expansion state behave as before.
+- Search within tree mode operates (TreeView built-in search) or page-level filters remain unchanged.
+- No regressions in list/table modes.
+

--- a/UI/src/components/pages/AdminAcademicPersonsPage.tsx
+++ b/UI/src/components/pages/AdminAcademicPersonsPage.tsx
@@ -467,15 +467,20 @@ export default function AdminAcademicPersonsPage() {
   };
 
   const convertToUITreeNode = (node: TreeNode): UITreeNode => {
+    const mapType = (t: TreeNode['type']): UITreeNode['type'] => {
+      if (t === 'university') return 'university';
+      if (t === 'faculty') return 'faculty';
+      if (t === 'school') return 'school';
+      // Fallback for person nodes to a supported type for iconography
+      return 'department';
+    };
+
     return {
       id: node.id,
       label: node.name_fr,
+      type: mapType(node.type),
       children: node.children ? node.children.map(convertToUITreeNode) : undefined,
-      isExpanded: node.expanded,
-      icon: node.type === 'university' ? Building2 : 
-            node.type === 'faculty' ? GraduationCap :
-            node.type === 'school' ? School : Users
-    } as unknown as UITreeNode;
+    } as UITreeNode;
   };
 
   const handleTreeNodeClick = (nodeId: string) => {
@@ -1152,8 +1157,11 @@ export default function AdminAcademicPersonsPage() {
               </h2>
               {treeData.length > 0 ? (
                 <TreeView
-                  data={treeData.map(convertToUITreeNode)}
-                  onNodeClick={handleTreeNodeClick}
+                  nodes={treeData.map(convertToUITreeNode)}
+                  searchable
+                  showCounts={false}
+                  showIcons
+                  maxHeight="500px"
                 />
               ) : (
                 <div className="text-center py-8 text-gray-500">

--- a/UI/src/utils/treeMappers.ts
+++ b/UI/src/utils/treeMappers.ts
@@ -1,0 +1,60 @@
+import { TreeNode as UITreeNode } from '../types/tree';
+import { TreeNodeData } from '../types/api';
+
+/**
+ * Generic mapper: converts API nested tree data (TreeNodeData) to UI TreeView nodes.
+ * A typeResolver decides the UI node type per depth and node.
+ */
+export function mapApiTreeToUiNodes(
+	data: TreeNodeData[],
+	typeResolver: (level: number, node: TreeNodeData, parent?: TreeNodeData) => UITreeNode['type']
+): UITreeNode[] {
+	const build = (node: TreeNodeData, level: number, parent?: TreeNodeData): UITreeNode => ({
+		id: node.id,
+		label: node.name_fr,
+		label_ar: node.name_ar,
+		label_en: node.name_en,
+		count: node.thesis_count || 0,
+		type: typeResolver(level, node, parent),
+		children: Array.isArray(node.children)
+			? node.children.map((child) => build(child, level + 1, node))
+			: undefined
+	});
+
+	return Array.isArray(data) ? data.map((n) => build(n, 0)) : [];
+}
+
+// Convenience resolvers
+export const universitiesHierarchyResolver = (
+	level: number
+): UITreeNode['type'] => {
+	if (level === 0) return 'university';
+	if (level === 1) return 'faculty';
+	return 'department';
+};
+
+export const schoolsHierarchyResolver = (
+	level: number
+): UITreeNode['type'] => {
+	if (level === 0) return 'school';
+	return 'department';
+};
+
+export const categoriesHierarchyResolver = (
+	level: number
+): UITreeNode['type'] => {
+	if (level === 0) return 'category';
+	if (level === 1) return 'subdiscipline';
+	if (level === 2) return 'specialty';
+	return 'category';
+};
+
+export const geographicHierarchyResolver = (
+	level: number
+): UITreeNode['type'] => {
+	if (level === 0) return 'location';
+	if (level === 1) return 'location';
+	if (level === 2) return 'location';
+	return 'location';
+};
+

--- a/UI/src/utils/treeMappers.ts
+++ b/UI/src/utils/treeMappers.ts
@@ -16,6 +16,7 @@ export function mapApiTreeToUiNodes(
 		label_en: node.name_en,
 		count: node.thesis_count || 0,
 		type: typeResolver(level, node, parent),
+		level,
 		children: Array.isArray(node.children)
 			? node.children.map((child) => build(child, level + 1, node))
 			: undefined


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds reusable tree-mapping utilities and updates AdminAcademicPersonsPage to the frozen TreeView API (nodes) with basic UI options; includes a foundation spec doc.
> 
> - **UI Utilities**:
>   - `UI/src/utils/treeMappers.ts`: Add `mapApiTreeToUiNodes(data, typeResolver)` plus resolvers: `universitiesHierarchyResolver`, `schoolsHierarchyResolver`, `categoriesHierarchyResolver`, `geographicHierarchyResolver`.
> - **Admin Academic Persons Page**:
>   - `UI/src/components/pages/AdminAcademicPersonsPage.tsx`:
>     - Switch `TreeView` prop from `data` to `nodes`; enable `searchable`, `showIcons`, `maxHeight`, `showCounts=false`.
>     - Update node conversion to set `type` via minimal mapping; remove inline `icon`/`isExpanded` wiring.
> - **Docs**:
>   - `FOUNDATION_PR_SPEC.md`: Define TreeView consolidation scope, non-goals, follow-ups, and acceptance criteria.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc394200d0e76b64db9873685ce2e9ba2a0a63e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->